### PR TITLE
Anpassung an Paragraph 29 Absatz 1 SdS

### DIFF
--- a/Mustersatzung.tex
+++ b/Mustersatzung.tex
@@ -416,7 +416,9 @@ Im Falle eines Widerspruchs dieser Satzung mit der Satzung der Studierendenschaf
 \section{Satzungsänderung}
 \begin{enumerate}[(1)]
     \item Diese Satzung behält ihre Gültigkeit bis sich die Fachschaft eine neue Satzung gibt.
-    \item Die Satzung kann durch Beschluss einer Änderungssatzung geändert werden. Für diesen Beschluss ist eine absolute Zweidrittelmehrheit der satzungsmäßigen FSV-Mitglieder oder eine Zweidrittelmehrheit auf einer beschlussfähigen FSVV nötig. Die Regelungen zu außerordentlichen FSV- und FSVV- Sitzungen sind unanwendbar (vgl § 10 Abs.7 und § 21 Abs. 5).
+    \item Die Satzung kann durch Beschluss einer Änderungssatzung geändert werden.
+    	Für diesen Beschluss ist eine absolute Zweidrittelmehrheit der satzungsmäßigen FSV-Mitglieder oder die Mehrheit der anwesenden Fachschaftsmitglieder auf einer beschlussfähigen FSVV nötig. 
+	Die Regelungen zu außerordentlichen FSV- und FSVV- Sitzungen sind unanwendbar (vgl § 10 Abs.7 und § 21 Abs. 5).
     \item Dieser Beschluss muss jedes Mal in drei Lesungen auf mindestens zwei getrennten Sitzungen gefasst werden, wobei die zweite und dritte Lesung in der gleichen Sitzung stattfinden dürfen.
     \item Der Tagesordnungspunkt „Satzungsänderung“ muss bereits in der Einladung zur betreffenden FSV-Sitzung oder FSVV-Sitzung angekündigt werden. In der Einladung müssen die zu ändernden Vorschriften ausdrücklich benannt werden. Dem Einladungsschreiben ist weiterhin der Wortlaut der beantragten Satzungsänderung beizufügen.
     \item Beschlüsse über Errichtung, Änderung oder Aufhebung der Fachschaftssatzung sind dem Fachschaftenkollektiv (FSK) und dem Präsidium des Studierendenparlaments vorab anzuzeigen.


### PR DESCRIPTION
Die SdS sagt zum Beschluss der Fachschachaftssatzung: "Die Fachschaft gibt sich nach Maßgabe dieser Satzung eine Fachschaftssatzung. Soweit eine FSV besteht, beschließt sie mit der Mehrheit von 2/3 ihrer Mitglieder; Ansonsten beschließt die FSVV mit der Mehrheit der anwesenden Fachschaftsmitglieder."